### PR TITLE
Fix matching logic in IranianAgent to prevent duplicate sensor matches

### DIFF
--- a/Models/Agents/IranianAgent.cs
+++ b/Models/Agents/IranianAgent.cs
@@ -22,11 +22,17 @@ namespace InvestigationGame.Models.Agents
         public int CountCorrectSensors()
         {
             int correct = 0;
+            var remaining = new List<string>(_weaknesses); // Make a copy
+
             foreach (var sensor in _attachedSensors)
             {
-                if (_weaknesses.Contains(sensor.Name))
+                if (remaining.Contains(sensor.Name))
+                {
                     correct++;
+                    remaining.Remove(sensor.Name); // Prevent re-counting
+                }
             }
+
             return correct;
         }
 


### PR DESCRIPTION
Fix matching logic in IranianAgent to prevent duplicate sensor matches